### PR TITLE
Add game header and basic car game

### DIFF
--- a/Codex-FrontEnd/Components/Layout/GameHeader.razor
+++ b/Codex-FrontEnd/Components/Layout/GameHeader.razor
@@ -1,0 +1,3 @@
+<nav class="game-header">
+    <NavLink class="game-link" href="car" Match="NavLinkMatch.All">Car Game</NavLink>
+</nav>

--- a/Codex-FrontEnd/Components/Layout/GameHeader.razor.css
+++ b/Codex-FrontEnd/Components/Layout/GameHeader.razor.css
@@ -1,0 +1,13 @@
+.game-header {
+    padding: 0.5rem 0;
+}
+
+.game-header ::deep .game-link {
+    margin-right: 1rem;
+    text-decoration: none;
+    color: #333;
+}
+
+.game-header ::deep .active {
+    font-weight: bold;
+}

--- a/Codex-FrontEnd/Components/Layout/MainLayout.razor
+++ b/Codex-FrontEnd/Components/Layout/MainLayout.razor
@@ -9,6 +9,9 @@
         <div class="top-row px-4">
             <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
         </div>
+        <div class="games-row px-4">
+            <GameHeader />
+        </div>
 
         <article class="content px-4">
             @Body

--- a/Codex-FrontEnd/Components/Layout/MainLayout.razor.css
+++ b/Codex-FrontEnd/Components/Layout/MainLayout.razor.css
@@ -21,6 +21,11 @@ main {
     align-items: center;
 }
 
+.games-row {
+    background-color: #f7f7f7;
+    border-bottom: 1px solid #d6d5d5;
+}
+
     .top-row ::deep a, .top-row ::deep .btn-link {
         white-space: nowrap;
         margin-left: 1.5rem;

--- a/Codex-FrontEnd/Components/Pages/CarGame.razor
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor
@@ -1,0 +1,17 @@
+@page "/car"
+@rendermode InteractiveServer
+@inject IJSRuntime JS
+
+<h1>Car Game</h1>
+<canvas id="car-canvas" width="400" height="400" style="border:1px solid #000" tabindex="0"></canvas>
+<script src="cargame.js"></script>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("carGame.init", "car-canvas");
+        }
+    }
+}

--- a/Codex-FrontEnd/Components/_Imports.razor
+++ b/Codex-FrontEnd/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using Codex_FrontEnd
 @using Codex_FrontEnd.Components
+@using Codex_FrontEnd.Components.Layout

--- a/Codex-FrontEnd/wwwroot/cargame.js
+++ b/Codex-FrontEnd/wwwroot/cargame.js
@@ -1,0 +1,26 @@
+window.carGame = {
+    init: function(canvasId) {
+        const canvas = document.getElementById(canvasId);
+        const ctx = canvas.getContext('2d');
+        const state = { x: 180, y: 180, size: 20 };
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.fillStyle = 'blue';
+            ctx.fillRect(state.x, state.y, state.size, state.size*2);
+        }
+
+        function handleKey(e) {
+            const step = 5;
+            if (e.key === 'ArrowUp') state.y -= step;
+            if (e.key === 'ArrowDown') state.y += step;
+            if (e.key === 'ArrowLeft') state.x -= step;
+            if (e.key === 'ArrowRight') state.x += step;
+            draw();
+        }
+
+        canvas.addEventListener('keydown', handleKey);
+        canvas.focus();
+        draw();
+    }
+};


### PR DESCRIPTION
## Summary
- introduce `GameHeader` component with styling
- show `GameHeader` from `MainLayout`
- add minimal car game page using canvas and JS
- import layout namespace so components are available

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685531f5499483329591c8f5749dc594