### PR TITLE
Add fullscreen responsive car game with enemy lanes

### DIFF
--- a/Codex-FrontEnd/Components/Pages/CarGame.razor
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor
@@ -3,7 +3,7 @@
 @inject IJSRuntime JS
 
 <h1>Car Game</h1>
-<canvas id="car-canvas" width="2400" height="400" style="border:1px solid #000" tabindex="0"></canvas>
+<canvas id="car-canvas" style="border:1px solid #000; width:100vw; height:100vh;" tabindex="0"></canvas>
 <script src="cargame.js"></script>
 
 @code {

--- a/Codex-FrontEnd/wwwroot/cargame.js
+++ b/Codex-FrontEnd/wwwroot/cargame.js
@@ -4,13 +4,25 @@ window.carGame = {
         const ctx = canvas.getContext('2d');
 
         const laneCount = 6;
-        const laneWidth = canvas.width / laneCount;
-        const carWidth = laneWidth * 0.6;
-        const carHeight = carWidth * 1.2;
+        let laneWidth;
+        let carWidth;
+        let carHeight;
 
         const state = { lane: Math.floor(laneCount / 2) };
-        const road = { x: 0, width: canvas.width };
-        const carY = canvas.height - carHeight - 20;
+        const road = { x: 0, width: 0 };
+        let carY;
+        const enemies = [];
+        let lastSpawn = 0;
+
+        function resize() {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+            laneWidth = canvas.width / laneCount;
+            carWidth = laneWidth * 0.6;
+            carHeight = carWidth * 1.2;
+            road.width = canvas.width;
+            carY = canvas.height - carHeight - 20;
+        }
 
         function laneCenter(lane) {
             return lane * laneWidth + laneWidth / 2 - carWidth / 2;
@@ -34,26 +46,64 @@ window.carGame = {
             ctx.setLineDash([]);
         }
 
-        function drawCar() {
+        function drawPlayer() {
             ctx.fillStyle = 'blue';
             ctx.fillRect(laneCenter(state.lane), carY, carWidth, carHeight);
+        }
+
+        function drawEnemies() {
+            ctx.fillStyle = 'red';
+            for (const e of enemies) {
+                ctx.fillRect(laneCenter(e.lane), e.y, carWidth, carHeight);
+            }
+        }
+
+        function spawnEnemy() {
+            enemies.push({ lane: Math.floor(Math.random() * laneCount), y: -carHeight });
+        }
+
+        function update(delta) {
+            for (const e of enemies) {
+                e.y += delta * 0.25; // speed factor
+            }
+            while (enemies.length && enemies[0].y > canvas.height) {
+                enemies.shift();
+            }
         }
 
         function draw() {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
 
             drawRoad();
-            drawCar();
+            drawPlayer();
+            drawEnemies();
         }
 
         function handleKey(e) {
             if (e.key === 'ArrowLeft') state.lane = Math.max(0, state.lane - 1);
             if (e.key === 'ArrowRight') state.lane = Math.min(laneCount - 1, state.lane + 1);
-            draw();
         }
 
         canvas.addEventListener('keydown', handleKey);
+        window.addEventListener('resize', resize);
+
+        resize();
         canvas.focus();
-        draw();
+
+        let lastTime = performance.now();
+        function gameLoop(timestamp) {
+            const delta = timestamp - lastTime;
+            lastTime = timestamp;
+
+            if (timestamp - lastSpawn > 1500) {
+                spawnEnemy();
+                lastSpawn = timestamp;
+            }
+
+            update(delta);
+            draw();
+            requestAnimationFrame(gameLoop);
+        }
+        requestAnimationFrame(gameLoop);
     }
 };


### PR DESCRIPTION
## Summary
- make the CarGame canvas take up the full viewport
- resize the canvas when the browser changes size
- generate enemy cars in lanes moving towards the player
- drive the game logic with an animation loop

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68553f9ef5a08332bce9d9fc83e552fd