### PR TITLE
Fix car game layout

### DIFF
--- a/Codex-FrontEnd/Components/Layout/MainLayout.razor
+++ b/Codex-FrontEnd/Components/Layout/MainLayout.razor
@@ -9,9 +9,7 @@
         <div class="top-row px-4">
             <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
         </div>
-        <div class="games-row px-4">
-            <GameHeader />
-        </div>
+
 
         <article class="content px-4">
             @Body

--- a/Codex-FrontEnd/Components/Pages/CarGame.razor
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor
@@ -2,8 +2,7 @@
 @rendermode InteractiveServer
 @inject IJSRuntime JS
 
-<h1>Car Game</h1>
-<canvas id="car-canvas" style="border:1px solid #000; width:100vw; height:100vh;" tabindex="0"></canvas>
+<canvas id="car-canvas" class="car-canvas" tabindex="0"></canvas>
 <script src="cargame.js"></script>
 
 @code {

--- a/Codex-FrontEnd/Components/Pages/CarGame.razor.css
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor.css
@@ -1,0 +1,6 @@
+.car-canvas {
+    width: 100%;
+    height: 100%;
+    border: 1px solid #000;
+    display: block;
+}

--- a/Codex-FrontEnd/wwwroot/cargame.js
+++ b/Codex-FrontEnd/wwwroot/cargame.js
@@ -15,8 +15,9 @@ window.carGame = {
         let lastSpawn = 0;
 
         function resize() {
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
+            const rect = canvas.getBoundingClientRect();
+            canvas.width = rect.width;
+            canvas.height = window.innerHeight - rect.top;
             laneWidth = canvas.width / laneCount;
             carWidth = laneWidth * 0.6;
             carHeight = carWidth * 1.2;


### PR DESCRIPTION
## Summary
- remove Car Game header and navigation row from the layout
- add a CSS class for the game canvas
- adjust canvas resizing logic to fit available area

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685541e427b083328710076cc42d8774