### PR TITLE
Implement scoring and leaderboard features

### DIFF
--- a/Codex-FrontEnd/Components/Pages/CarGame.razor
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor
@@ -3,9 +3,15 @@
 @inject IJSRuntime JS
 
 <canvas id="car-canvas" class="car-canvas" tabindex="0"></canvas>
+<div class="score-panel">
+    <div id="score-display" class="score-display">Score: 0</div>
+    <div id="leaderboard" class="leaderboard"></div>
+</div>
 <div id="reset-overlay" class="reset-overlay">
     <div class="reset-content">
-        <p>Collision! Reset game?</p>
+        <p id="collision-text">Collision! Reset game?</p>
+        <input id="name-input" placeholder="Enter your name" />
+        <button id="submit-score" class="btn btn-secondary">Submit Score</button>
         <button id="reset-button" class="btn btn-primary">Reset</button>
     </div>
 </div>

--- a/Codex-FrontEnd/Components/Pages/CarGame.razor.css
+++ b/Codex-FrontEnd/Components/Pages/CarGame.razor.css
@@ -23,3 +23,25 @@
     border-radius: 4px;
     text-align: center;
 }
+
+.reset-content input {
+    width: 100%;
+    margin: 10px 0;
+}
+
+.score-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 10px;
+    text-align: right;
+}
+
+.score-display {
+    font-weight: bold;
+}
+
+.leaderboard {
+    margin-top: 10px;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- show current score and leaderboard in `CarGame`
- add styling for score panel and leaderboard
- implement JS logic for scoring, leaderboard, and focus on reset

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855516c0f6c8332a8c7ec680b54670c